### PR TITLE
update pam-watchid repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ mi      ALL = NOPASSWD: /usr/local/sbin/mtr,/usr/local/bin/grc,/sbin/ping,/sbin/
 ```
 
 ### pam-watchid
-Run sudo with your Apple Watch. See [Logicer16/pam-watchid](https://github.com/Logicer16/pam-watchid) to install PAM module.
+Run sudo with your Apple Watch. See [mostpinkest/pam-watchid](https://github.com/mostpinkest/pam-watchid) to install PAM module.
 
 ```
-% /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/logicer16/pam-watchid/HEAD/install.sh)" -- enable
+% /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mostpinkest/pam-watchid/HEAD/install.sh)" -- enable
  ```
 
 Add the following line to the top of `/etc/pam.d/sudo`.


### PR DESCRIPTION
I have recently been required to change my GitHub username. I'm sending PRs to anywhere using any of my repos from a basic GitHub search. GitHub currently has redirects for old repo URLs, but this may change in the future. 

You're welcome to verify that https://github.com/Logicer16/pam-watchid redirects to https://github.com/mostpinkest/pam-watchid